### PR TITLE
Support prefix pattern

### DIFF
--- a/lib/ember/es6_template/config.rb
+++ b/lib/ember/es6_template/config.rb
@@ -2,10 +2,35 @@ module Ember
   module ES6Template
     class Config
       attr_accessor :module_prefix
+      attr_reader :prefix_dirs, :prefix_files
+
+      def prefix_dirs=(dirs)
+        @prefix_pattern = nil
+
+        @prefix_dirs = dirs
+      end
+
+      def prefix_files=(files)
+        @prefix_pattern = nil
+
+        @prefix_files = files
+      end
+
+      def prefix_pattern
+        @prefix_pattern ||= begin
+          patterns = []
+          patterns += Array(prefix_dirs).map {|dir| Regexp.new("^#{dir}/") }
+          patterns += Array(prefix_files).map {|file| Regexp.new("^#{file}$") }
+
+          patterns.empty? ? // : Regexp.union(patterns)
+        end
+      end
 
       def to_hash
         {
-          module_prefix: module_prefix
+          module_prefix: module_prefix,
+          prefix_files: prefix_files,
+          prefix_dirs: prefix_dirs
         }
       end
     end

--- a/lib/ember/es6_template/sprockets2/es6module.rb
+++ b/lib/ember/es6_template/sprockets2/es6module.rb
@@ -24,7 +24,15 @@ module Ember
       private
 
       def module_name(path)
-        [Ember::ES6Template.config.module_prefix, path].compact.join('/')
+        paths = []
+        paths << config.module_prefix if config.prefix_pattern =~ path
+        paths << path
+
+        paths.compact.join('/')
+      end
+
+      def config
+        Ember::ES6Template.config
       end
     end
   end

--- a/lib/ember/es6_template/sprockets3/es6module.rb
+++ b/lib/ember/es6_template/sprockets3/es6module.rb
@@ -62,7 +62,11 @@ module Ember
           end
         end
 
-        [@config.module_prefix, module_name].compact.join('/')
+        paths = []
+        paths << @config.module_prefix if @config.prefix_pattern =~ module_name
+        paths << module_name
+
+        paths.compact.join('/')
       end
     end
   end

--- a/test/fixtures/controllers/welcome.module.es6
+++ b/test/fixtures/controllers/welcome.module.es6
@@ -1,0 +1,1 @@
+export default Controller;

--- a/test/fixtures/non-ember/boot.module.es6
+++ b/test/fixtures/non-ember/boot.module.es6
@@ -1,0 +1,1 @@
+export default boot;

--- a/test/test_ember_es6_template.rb
+++ b/test/test_ember_es6_template.rb
@@ -160,17 +160,66 @@ define("ping/controller", ["exports", "module"], function (exports, module) {
     end
   end
 
+  def test_configure_prefix_files
+    with_module_prefix_with_prefix_files_and_dirs('hi', 'controller', nil) do
+      asset = @env['controller.js']
+      assert { %r{define\("hi/controller"} =~ asset.to_s.strip }
+
+      asset = @env['controllers/index.js']
+      assert { %r{define\("controllers/index"} =~ asset.to_s.strip }
+    end
+  end
+
+  def test_configure_prefix_dirs
+    with_module_prefix_with_prefix_files_and_dirs('hi', nil, 'controllers') do
+      asset = @env['controllers/index.js']
+      assert { %r{define\("hi/controllers/index"} =~ asset.to_s.strip }
+
+      asset = @env['controller.js']
+      assert { %r{define\("controller"} =~ asset.to_s.strip }
+    end
+  end
+
+  def test_configure_prefix_files_and_dirs
+    with_module_prefix_with_prefix_files_and_dirs('hi', 'index', 'controllers') do
+      asset = @env['controllers/index.js']
+      assert { %r{define\("hi/controllers/index"} =~ asset.to_s.strip }
+
+      asset = @env['controllers/welcome.js']
+      assert { %r{define\("hi/controllers/welcome"} =~ asset.to_s.strip }
+
+      asset = @env['index.js']
+      assert { %r{define\("hi/index"} =~ asset.to_s.strip }
+
+      asset = @env['index.js']
+      assert { %r{define\("hi/index"} =~ asset.to_s.strip }
+
+      asset = @env['non-ember/boot.js']
+      assert { %r{define\("non-ember/boot"} =~ asset.to_s.strip }
+    end
+  end
+
   private
 
   def with_module_prefix(prefix)
+    with_module_prefix_with_prefix_files_and_dirs(prefix, nil, nil) do
+      yield
+    end
+  end
+
+  def with_module_prefix_with_prefix_files_and_dirs(prefix, files, dirs)
     Ember::ES6Template.configure do |config|
       prefix, config.module_prefix = config.module_prefix, prefix
+      files, config.prefix_files = config.prefix_files, files
+      dirs, config.prefix_dirs = config.prefix_dirs, dirs
     end
 
     yield
   ensure
     Ember::ES6Template.configure do |config|
-      config.module_prefix = prefix
+      prefix, config.module_prefix = config.module_prefix, prefix
+      files, config.prefix_files = config.prefix_files, files
+      dirs, config.prefix_dirs = config.prefix_dirs, dirs
     end
   end
 end


### PR DESCRIPTION
For example:

``` ruby
Ember::ES6Template.configure do |config|
  config.module_prefix = 'emebr-app'
  config.prefix_files = ['store', 'router']
  config.prefix_dirs = ['models', 'controllers']
end
```
