### PR TITLE
Make module formatter strict

### DIFF
--- a/lib/ember/es6_template/sprockets2/es6.rb
+++ b/lib/ember/es6_template/sprockets2/es6.rb
@@ -13,6 +13,7 @@ module Ember
         return data if module?(scope.pathname.to_s)
 
         result = Babel::Transpiler.transform(data,
+          'modules' => 'commonStrict',
           'sourceRoot' => env.root,
           'moduleRoot' => '',
           'filename' => scope.logical_path

--- a/lib/ember/es6_template/sprockets2/es6module.rb
+++ b/lib/ember/es6_template/sprockets2/es6module.rb
@@ -11,7 +11,7 @@ module Ember
         env = scope.environment
 
         result = Babel::Transpiler.transform(data,
-          'modules' => 'amd',
+          'modules' => 'amdStrict',
           'moduleIds' => true,
           'sourceRoot' => env.root,
           'moduleRoot' => '',

--- a/lib/ember/es6_template/sprockets3/es6.rb
+++ b/lib/ember/es6_template/sprockets3/es6.rb
@@ -29,6 +29,7 @@ module Ember
 
       def transform(data, input)
         Babel::Transpiler.transform(data,
+          'modules' => 'commonStrict',
           'sourceRoot' => input[:load_path],
           'moduleRoot' => '',
           'filename' => input[:filename]

--- a/lib/ember/es6_template/sprockets3/es6module.rb
+++ b/lib/ember/es6_template/sprockets3/es6module.rb
@@ -33,7 +33,7 @@ module Ember
 
       def transform(data, input)
         Babel::Transpiler.transform(data,
-          'modules' => 'amd',
+          'modules' => 'amdStrict',
           'moduleIds' => true,
           'sourceRoot' => input[:load_path],
           'moduleRoot' => '',

--- a/test/fixtures/import.es6
+++ b/test/fixtures/import.es6
@@ -1,1 +1,3 @@
 import Hi from 'hi';
+
+Hi.create();

--- a/test/test_ember_es6_template.rb
+++ b/test/test_ember_es6_template.rb
@@ -32,11 +32,9 @@ class TestEmberES6Template < Minitest::Test
     expected = <<-JS.strip
 'use strict';
 
-var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { 'default': obj }; };
-
 var _Hi = require('hi');
 
-var _Hi2 = _interopRequireWildcard(_Hi);
+_Hi['default'].create();
     JS
 
     assert { expected == asset.to_s.strip }
@@ -47,10 +45,10 @@ var _Hi2 = _interopRequireWildcard(_Hi);
     assert { 'application/javascript' == asset.content_type }
 
     expected = <<-JS.strip
-define("controller", ["exports", "module"], function (exports, module) {
+define("controller", ["exports"], function (exports) {
   "use strict";
 
-  module.exports = Ember.Controller.extend({});
+  exports["default"] = Ember.Controller.extend({});
 });
     JS
 
@@ -62,10 +60,10 @@ define("controller", ["exports", "module"], function (exports, module) {
     assert { 'application/javascript' == asset.content_type }
 
     expected = <<-JS.strip
-define("env", ["exports", "module"], function (exports, module) {
+define("env", ["exports"], function (exports) {
   "use strict";
 
-  module.exports = {
+  exports["default"] = {
     key: "1024"
   };
 });
@@ -88,9 +86,7 @@ App.create();
       <<-JS.strip
 var _App = require('application');
 
-var _App2 = _interopRequireWildcard(_App);
-
-_App2['default'].create();
+_App['default'].create();
       JS
     end
 
@@ -102,10 +98,10 @@ _App2['default'].create();
     assert { 'application/javascript' == asset.content_type }
 
     expected = <<-JS.strip
-define("route", ["exports", "module"], function (exports, module) {
+define("route", ["exports"], function (exports) {
   "use strict";
 
-  module.exports = Route;
+  exports["default"] = Route;
   ;
 });
     JS
@@ -118,10 +114,10 @@ define("route", ["exports", "module"], function (exports, module) {
     assert { 'application/javascript' == asset.content_type }
 
     expected = <<-JS.strip
-define("index", ["exports", "module"], function (exports, module) {
+define("index", ["exports"], function (exports) {
   "use strict";
 
-  module.exports = IndexRoute;
+  exports["default"] = IndexRoute;
 });
     JS
 
@@ -133,10 +129,10 @@ define("index", ["exports", "module"], function (exports, module) {
     assert { 'application/javascript' == asset.content_type }
 
     expected = <<-JS.strip
-define("controllers/index", ["exports", "module"], function (exports, module) {
+define("controllers/index", ["exports"], function (exports) {
   "use strict";
 
-  module.exports = Controller;
+  exports["default"] = Controller;
 });
     JS
 
@@ -149,10 +145,10 @@ define("controllers/index", ["exports", "module"], function (exports, module) {
       assert { 'application/javascript' == asset.content_type }
 
       expected = <<-JS.strip
-define("ping/controller", ["exports", "module"], function (exports, module) {
+define("ping/controller", ["exports"], function (exports) {
   "use strict";
 
-  module.exports = Ember.Controller.extend({});
+  exports["default"] = Ember.Controller.extend({});
 });
       JS
 


### PR DESCRIPTION
babel inserts checking of `__esModule` in non-strict formatter.
But assets from other projects (such as Emebr CLI) have no its internal property.
