### PR TITLE
Drop Ruby 2.0.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ cache: bundler
 sudo: false
 
 rvm:
-  - 2.0.0
   - 2.1
   - 2.2.4
   - 2.3.0


### PR DESCRIPTION
Ruby 2.0.0's support has ended.
https://www.ruby-lang.org/en/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1/
