### PR TITLE
Bugfix -  caching of coffee script modules with identical content

### DIFF
--- a/lib/ember/es6_template/sprockets/coffee_script_helper.rb
+++ b/lib/ember/es6_template/sprockets/coffee_script_helper.rb
@@ -3,9 +3,10 @@ module Ember
     module CoffeeScriptHelper
       def call(input)
         data = input[:data]
+        filename = input[:filename]
 
-        result = input[:cache].fetch(_cache_key + [data]) do
-          if es6?(input[:filename])
+        result = input[:cache].fetch(_cache_key + [filename, data]) do
+          if es6?(filename)
             transform(
               Sprockets::Autoload::CoffeeScript.compile(data, bare: true),
               input

--- a/test/fixtures/route-two.module.coffee
+++ b/test/fixtures/route-two.module.coffee
@@ -1,0 +1,1 @@
+`export default Route;`

--- a/test/test_ember_es6_template.rb
+++ b/test/test_ember_es6_template.rb
@@ -109,6 +109,13 @@ define("route", ["exports"], function (exports) {
     assert { expected == asset.to_s.strip }
   end
 
+  def test_transpile_module_files_with_identical_content
+    asset = @env['route.js']
+    asset_two = @env['route-two.js']
+
+    assert { asset.to_s.strip != asset_two.to_s.strip }
+  end
+
   def test_transpile_coffee_script
     asset = @env['non-ember/just-coffee.js']
     assert { 'application/javascript' == asset.content_type }


### PR DESCRIPTION
Files with identical content but different names were being
cached under the same key and therefore only the 1st file had the
correct export. As this output was returned (same export) for all
subsequence files with the same content.

This is pronounced in Ember with things like Adaptors where content
can frequently be identical but nameing convention is important
for resolver resolution eg.

_adapters/model-one.module.coffee_
```
export default ApplicationAdapter.extend
  coalesceFindRequests: true
```

_adapters/model-two.module.coffee_
```
export default ApplicationAdapter.extend
  coalesceFindRequests: true
```

`require('adapters/model-one')`
would work as expected but

`require('adapters/model-two')`
would result in runtime error Could not find module 'adapters/model-two'

As no export gets defined for 'adapters/model-two'
due to the skipped transform step

Simplest fix Seems to be, just include the filepath in the cache
key.